### PR TITLE
Add toggle to handle shortcut response.

### DIFF
--- a/src/LauncherModal.ts
+++ b/src/LauncherModal.ts
@@ -6,12 +6,14 @@ export class LauncherModal extends Modal {
 	shortcutName: string;
 	inputTypes: string[];
 	separator: string;
+	insertShortcutText: boolean;
 
 	onSave: (
 		commandName: string,
 		shortcutName: string,
 		inputTypes: string[],
-		separator: string
+		separator: string,
+		insertShortcutText: boolean,
 	) => void;
 
 	constructor(
@@ -21,11 +23,13 @@ export class LauncherModal extends Modal {
 		shortcutName: string,
 		inputTypes: string[],
 		separator: string,
+		insertShortcutText: boolean,
 		onSave: (
 			commandName: string,
 			shortcutName: string,
 			inputTypes: string[],
-			separator: string
+			separator: string,
+			insertShortcutText: boolean,
 		) => void
 	) {
 		super(app);
@@ -34,6 +38,7 @@ export class LauncherModal extends Modal {
 		this.shortcutName = shortcutName;
 		this.inputTypes = inputTypes;
 		this.separator = separator;
+		this.insertShortcutText = insertShortcutText;
 		this.onSave = onSave;
 	}
 
@@ -155,26 +160,39 @@ export class LauncherModal extends Modal {
 				);
 		}
 
-		new Setting(contentEl).addButton((button) =>
-			button
-				.setButtonText("Save")
-				.setCta()
-				.onClick(() => {
-					if (!this.commandName || this.commandName.length == 0) {
-						return new Notice("Specify a command name.");
-					}
-					if (!this.shortcutName || this.shortcutName.length == 0) {
-						return new Notice("Specify a shortcut name.");
-					}
-					this.onSave(
-						this.commandName,
-						this.shortcutName,
-						this.inputTypes,
-						this.separator
-					);
-					this.close();
-				})
-		);
+		new Setting(contentEl)
+			.setName("Insert shortcut text")
+			.setDesc("Insert the response from the shortcut after the cursor or selected text.")
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.insertShortcutText)
+					.onChange((value) => {
+						(this.insertShortcutText = value)
+					})
+			);
+
+		new Setting(contentEl)
+			.addButton((button) =>
+				button
+					.setButtonText("Save")
+					.setCta()
+					.onClick(() => {
+						if (!this.commandName || this.commandName.length == 0) {
+							return new Notice("Specify a command name.");
+						}
+						if (!this.shortcutName || this.shortcutName.length == 0) {
+							return new Notice("Specify a shortcut name.");
+						}
+						this.onSave(
+							this.commandName,
+							this.shortcutName,
+							this.inputTypes,
+							this.separator,
+							this.insertShortcutText
+						);
+						this.close();
+					})
+			);
 	}
 
 	onClose() {

--- a/src/SettingsTab.ts
+++ b/src/SettingsTab.ts
@@ -29,12 +29,14 @@ export class SettingsTab extends PluginSettingTab {
 						"",
 						["Selected Text"],
 						",",
-						(commandName, shortcutName, inputTypes, separator) => {
+						false,
+						(commandName, shortcutName, inputTypes, separator, insertShortcutText) => {
 							this.plugin.settings.launchers.splice(0, 0, {
-								commandName: commandName,
-								shortcutName: shortcutName,
-								inputTypes: inputTypes,
-								separator: separator,
+								commandName,
+								shortcutName,
+								inputTypes,
+								separator,
+								insertShortcutText,
 							});
 							this.plugin.saveSettings();
 							this.display();
@@ -56,11 +58,13 @@ export class SettingsTab extends PluginSettingTab {
 							launcher.shortcutName,
 							launcher.inputTypes,
 							launcher.separator,
+							launcher.insertShortcutText,
 							(
 								commandName,
 								shortcutName,
 								inputTypes,
-								separator
+								separator,
+								insertShortcutText,
 							) => {
 								this.plugin.settings.launchers[
 									index
@@ -74,6 +78,9 @@ export class SettingsTab extends PluginSettingTab {
 								this.plugin.settings.launchers[
 									index
 								].separator = separator;
+								this.plugin.settings.launchers[
+									index
+								].insertShortcutText = insertShortcutText;
 								this.plugin.saveSettings();
 								this.display();
 							}

--- a/src/main.ts
+++ b/src/main.ts
@@ -68,7 +68,7 @@ export default class ShortcutLauncherPlugin extends Plugin {
             this.lastLauncher = undefined;
             this.hideStatusBarIcon()
             new Notice(
-				`There was an error running your shortcut: ${perams}`
+				`There was an error running your shortcut`
 			);
         });
 	}
@@ -276,10 +276,16 @@ export default class ShortcutLauncherPlugin extends Plugin {
 							            (error, stdout, stderr) => {
 							                if (error) {
 							                    console.error(`exec error: ${error}`);
+							                    new Notice(
+													`There was an error running your shortcut`
+												);
 							                    return;
 							                }
 							                if (stderr) {
 							                    console.error(`stderr: ${stderr}`);
+							                    new Notice(
+													`There was an error running your shortcut`
+												);
 							                    return;
 							                }
 							                this.hideStatusBarIcon()

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import * as obsidian from 'obsidian';
 import {
 	Command,
 	getLinkpath,
@@ -8,6 +9,8 @@ import {
 	ReferenceCache,
 } from "obsidian";
 import { SettingsTab } from "./SettingsTab";
+
+const pluginCallbackPath = 'obsidian-shortcut-launcher';
 
 declare module "obsidian" {
 	interface Commands {
@@ -39,11 +42,35 @@ const DEFAULT_SETTINGS: ShortcutLauncherPluginSettings = {
 export default class ShortcutLauncherPlugin extends Plugin {
 	settings: ShortcutLauncherPluginSettings;
 	registeredCommands: Command[] = [];
+	private lastLauncher;
+	private statusBarIcon;
 
 	async onload() {
 		await this.loadSettings();
 		this.addSettingTab(new SettingsTab(this.app, this));
 		await this.createCommands();
+		this.registerCallbacks()
+	}
+
+	registerCallbacks() {
+		// Register the callback handlers
+        this.registerObsidianProtocolHandler(`${pluginCallbackPath}/success`, async (params) => {
+            // Handle the success response from the iOS Shortcut
+            // console.log(`Shortcut success:`, params);
+            this.handleShortcutResponse(params.result, this.lastLauncher)
+            this.lastLauncher = undefined;
+            this.hideStatusBarIcon()
+        });
+
+        this.registerObsidianProtocolHandler(`${pluginCallbackPath}/error`, async (params) => {
+            // Handle the error response from the iOS Shortcut
+            console.error(`Shortcut error:`, params);
+            this.lastLauncher = undefined;
+            this.hideStatusBarIcon()
+            new Notice(
+				`There was an error running your shortcut: ${perams}`
+			);
+        });
 	}
 
 	async createCommands() {
@@ -68,9 +95,7 @@ export default class ShortcutLauncherPlugin extends Plugin {
 									text =
 										this.app.workspace.activeEditor?.editor?.getSelection() ||
 										"";
-								} else if (
-									inputType == "Selected Link/Embed Contents"
-								) {
+								} else if (inputType == "Selected Link/Embed Contents") {
 									let metadataCache =
 										this.app.metadataCache.getFileCache(
 											this.app.workspace.getActiveFile()!
@@ -218,40 +243,49 @@ export default class ShortcutLauncherPlugin extends Plugin {
 								inputs.push(text);
 							}, Promise.resolve())
 							.then(() => {
+								this.showStatusBarIcon(launcher)
 								if (Platform.isMobileApp) {
-									window.open(
-										`shortcuts://run-shortcut?name=${encodeURIComponent(
-											launcher.shortcutName
-										)}&input=text&text=${encodeURIComponent(
-											inputs.join(launcher.separator)
-										)}`
-									);
+								    // Define the base URL for the Actions URI plugin
+							        const actionsUriBase = 'obsidian://';
+
+							        // Construct the x-success and x-error URLs
+							        const xSuccessURL = launcher.insertShortcutText ? `${actionsUriBase}obsidian-shortcut-launcher/success` : '';
+							        const xErrorURL = `${actionsUriBase}${pluginCallbackPath}/error`;
+
+							        // Encode the URLs for inclusion in the Shortcut URL
+							        const encodedXSuccessURL = encodeURIComponent(xSuccessURL);
+							        const encodedXErrorURL = encodeURIComponent(xErrorURL);
+
+							        // Construct the URL to call the iOS Shortcut
+							        const url = `shortcuts://run-shortcut?name=${encodeURIComponent(
+							            launcher.shortcutName
+							        )}&input=text&text=${encodeURIComponent(
+							            inputs.join(launcher.separator)
+							        )}&x-success=${encodedXSuccessURL}&x-error=${encodedXErrorURL}`;
+							        this.lastLauncher = launcher;
+							        // Open the Shortcut URL
+							        window.open(url);
 								} else {
-									let tempFilePath = require("path").join(
-										require("os").tmpdir(),
-										"obsidian-shortcut-launcher-temp-input"
-									);
 									let escapedShortcutName =
 										launcher.shortcutName.replace(
 											/["\\]/g,
 											"\\$&"
 										);
-									let fs = require("fs");
-									fs.writeFile(
-										tempFilePath,
-										inputs.join(launcher.separator),
-										() => {
-											require("child_process").exec(
-												`shortcuts run "${escapedShortcutName}" -i ${tempFilePath}`,
-												async () => {
-													fs.unlink(
-														tempFilePath,
-														() => {}
-													);
-												}
-											);
-										}
-									);
+									const child = require("child_process").exec(
+							            `echo "${inputs.join(launcher.separator).replace(/"/g, '\\"')}" | shortcuts run "${escapedShortcutName}"`,
+							            (error, stdout, stderr) => {
+							                if (error) {
+							                    console.error(`exec error: ${error}`);
+							                    return;
+							                }
+							                if (stderr) {
+							                    console.error(`stderr: ${stderr}`);
+							                    return;
+							                }
+							                this.hideStatusBarIcon()
+							                this.handleShortcutResponse(stdout, launcher);
+							            }
+							        );
 								}
 							});
 						return true;
@@ -259,6 +293,59 @@ export default class ShortcutLauncherPlugin extends Plugin {
 				})
 			);
 		});
+	}
+
+	handleShortcutResponse(output, launcher) {
+	    // Check if the setting to insert text is enabled
+	    console.log(`shortcut responded with ${output}`);
+
+	    if (!launcher.insertShortcutText) {
+	        // If the setting is not enabled, simply log and return without inserting
+	        console.log('Inserting text from shortcut is disabled.');
+	        return;
+	    }
+
+	    // Get the active leaf (pane) in Obsidian
+	    const activeLeaf = app.workspace.activeLeaf;
+
+	    // Check if the active leaf has an editor instance
+	    if (activeLeaf && activeLeaf.view instanceof obsidian.MarkdownView) {
+	        const editor = activeLeaf.view.editor;
+	        const doc = editor.getDoc();
+
+	        // Prepare the text to be inserted, including the launcher's command name
+	        const textToInsert = `\n**${launcher.commandName}**: ${output}\n`;
+
+	        // Get the current cursor position
+	        const cursorPos = doc.getCursor();
+
+	        // Insert the text right after the current cursor position
+	        doc.replaceRange(textToInsert, cursorPos);
+
+	        // Move the cursor to the end of the inserted text
+	        // Since we've inserted text, calculate the new cursor position
+	        const linesInserted = textToInsert.split('\n').length - 1;
+	        const newCursorPos = {
+	            line: cursorPos.line + linesInserted,
+	            ch: linesInserted > 0 ? 0 : cursorPos.ch + textToInsert.length
+	        };
+	        doc.setCursor(newCursorPos);
+	    }
+	}
+
+	showStatusBarIcon(launcher) {
+	    // Get the status bar element
+	    this.statusBarIcon = this.addStatusBarItem()
+	    this.statusBarIcon.setText(`Running Shortcut: ${launcher.commandName}...`)
+	    // app.workspace.statusBarEl.createEl('div', { text: `Running Shortcut: ${launcher.commandName}...` });
+	}
+
+	hideStatusBarIcon() {
+	    // Remove the status bar item if it exists
+	    if (this.statusBarIcon) {
+	        this.statusBarIcon.remove();
+	        this.statusBarIcon = null;
+	    }
 	}
 
 	check(launcher: Launcher): boolean {


### PR DESCRIPTION
- Adds status bar text "Running Shortcut: ${launcher.commandName}"
- Adds setting to handle shortcut response and insert in to document

Addresses the request in https://github.com/macstories/obsidian-shortcut-launcher/issues/7


This almost works for me.

<img width="584" alt="image" src="https://github.com/macstories/obsidian-shortcut-launcher/assets/4664956/0065de19-7d1e-4a1f-8f5c-a3921816ab0a">

<img width="573" alt="image" src="https://github.com/macstories/obsidian-shortcut-launcher/assets/4664956/fc1c2234-eec8-48ee-946c-6b44e80e64a6">

There is one bug in the insertion logic as it initially looks like this:

<img width="571" alt="image" src="https://github.com/macstories/obsidian-shortcut-launcher/assets/4664956/c756d829-c5fa-46ef-86bb-af51bb460cbe">


If someone could help me clean that up, i think this might be a decent candidate to mainline.